### PR TITLE
(Maybe) add a silly web extension

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,7 +3,7 @@ Architecture
 
 This document contains an overview description of Dinghy's architecture.
 
-From the point of view “what gets built”, Dinghy is split in three components:
+From the point of view “what gets built”, Dinghy is split in four components:
 
 - `dinghy`: The launcher itself. Built from [dinghy.c](dinghy.c), uses
   `libdinghycore`.
@@ -17,7 +17,10 @@ From the point of view “what gets built”, Dinghy is split in three component
 - `libdinghycore`: Library which contains most of the functionality used to
   implement the launcher, in reusable form.
 
-Most of the items described below are built as part of the latter.
+- `dinghy-web-extension`: The web process extension (InjectedBundle) to be
+  dlopened by the web process.
+
+Most of the items described below are built as part of `libdinghycore`.
 
 
 DyLauncher

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 add_definitions(-DDY_INSIDE_DINGHY__=1)
 add_definitions(-DG_LOG_DOMAIN=\"Dy\")
+add_definitions(-DPKGLIBDIR="${CMAKE_INSTALL_FULL_LIBDIR}/dinghy")
 
 configure_file(dy-config.h.in dy-config.h @ONLY)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -60,8 +61,10 @@ pkg_check_modules(SOUP REQUIRED libsoup-2.4)
 if (DY_USE_WEBKITGTK)
 	list(APPEND DINGHYCORE_SOURCES dy-gtk-utils.c)
 	pkg_check_modules(WEB_ENGINE REQUIRED webkit2gtk-4.0)
+	pkg_check_modules(WEB_EXTENSION REQUIRED webkit2gtk-4.0-web-extension)
 else ()
 	pkg_check_modules(WEB_ENGINE REQUIRED wpe-webkit wpe)
+	pkg_check_modules(WEB_EXTENSION REQUIRED wpe-web-extension)
 endif ()
 
 set(DINGHYCORE_INCLUDE_DIRS ${WEB_ENGINE_INCLUDE_DIRS} ${SOUP_INCLUDE_DIRS})
@@ -96,6 +99,11 @@ set_property(TARGET dinghycore PROPERTY C_STANDARD 99)
 target_include_directories(dinghycore PUBLIC ${DINGHYCORE_INCLUDE_DIRS})
 target_link_libraries(dinghycore ${DINGHYCORE_LDFLAGS})
 
+add_library(dinghywebextension MODULE dy-web-extension.c)
+set_property(TARGET dinghywebextension PROPERTY C_STANDARD 99)
+target_include_directories(dinghywebextension PRIVATE ${WEB_EXTENSION_INCLUDE_DIRS})
+target_link_libraries(dinghywebextension ${WEB_EXTENSION_LDFLAGS})
+
 add_executable(dinghy dinghy.c)
 set_property(TARGET dinghy PROPERTY C_STANDARD 99)
 target_link_libraries(dinghy dinghycore)
@@ -112,6 +120,10 @@ install(TARGETS dinghy dinghyctl
 install(TARGETS dinghycore
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	COMPONENT ${DINGHYCORE_COMPONENT}
+)
+install(TARGETS dinghywebextension
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/dinghy
+	COMPONENT "runtime"
 )
 install(FILES ${DINGHYCORE_API_HEADERS}
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dinghy

--- a/dy-launcher.c
+++ b/dy-launcher.c
@@ -101,6 +101,13 @@ make_action (const char *name, void (*callback) (DyLauncher*))
     return action;
 }
 
+static void
+on_initialize_web_extensions (WebKitWebContext *context,
+                              void             *user_data)
+{
+    webkit_web_context_set_web_extensions_directory (context, PKGLIBDIR);
+}
+
 
 typedef struct _RequestHandlerMapEntry RequestHandlerMapEntry;
 static void request_handler_map_entry_register (const char*, RequestHandlerMapEntry*, WebKitWebContext*);
@@ -132,6 +139,9 @@ dy_launcher_create_web_context (DyLauncher *launcher)
                               (GHFunc) request_handler_map_entry_register,
                               launcher->web_context);
     }
+
+    g_signal_connect (launcher->web_context, "initialize-web-extensions",
+                      G_CALLBACK (on_initialize_web_extensions), NULL);
 }
 
 

--- a/dy-web-extension.c
+++ b/dy-web-extension.c
@@ -1,0 +1,30 @@
+/*
+ * dinghy.c
+ * Copyright (C) 2018 Igalia S.L.
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#include <stdlib.h>
+#include <wpe/webkit-web-extension.h>
+
+static void
+on_web_page_created (WebKitWebExtension *extension,
+                     WebKitWebPage      *page,
+                     void               *user_data)
+{
+    /*
+     * In the future, we might want to do something interesting here.
+     * Currently, we just print something to show that we have the
+     * ability to code in the web process.
+     */
+    if (g_getenv ("DINGHY_WEB_EXTENSION_DEMO"))
+        g_message ("Created page #%" G_GUINT64_FORMAT, webkit_web_page_get_id (page));
+}
+
+G_MODULE_EXPORT void
+webkit_web_extension_initialize (WebKitWebExtension *extension)
+{
+    g_signal_connect (extension, "page-created",
+                      G_CALLBACK (on_web_page_created), NULL);
+}


### PR DESCRIPTION
When run with DINGHY_WEB_EXTENSION_DEMO, dinghy will now print out the
page ID of every newly-created WebKitWebPage in the web process. This is
silly, but it shows that we can run code in the web process.

In the future, the demo functionality could be removed and replaced with
something that would actually be useful, e.g. an adblocker.

Note: this depends on [this WebKit patch](https://bugs.webkit.org/show_bug.cgi?id=179915), which needs to land before this is merged.

Note also: this is kinda dumb, so it's OK to leave it on a sidebranch if you prefer. I just needed it to test that installed extensions actually work. But it will be useful to have if you ever want to do something that needs a web extension in the future.

Note finally: you should be ashamed of the hard tabs in the CMakeLists.txt :P