### PR TITLE
Fix implicit declaration of exit

### DIFF
--- a/dy-webkit-utils.c
+++ b/dy-webkit-utils.c
@@ -6,6 +6,7 @@
  */
 
 #include "dy-webkit-utils.h"
+#include <stdlib.h>
 #include <string.h>
 
 


### PR DESCRIPTION
Looks like this code probably never worked.

```
[4/11] Building C object CMakeFiles/dinghycore.dir/dy-webkit-utils.c.o
/home/mcatanzaro/Projects/WebKit/WebKitBuild/DependenciesWPE/Source/dinghy/dy-webkit-utils.c: In function ‘dy_handle_web_view_web_process_crashed_exit’:
/home/mcatanzaro/Projects/WebKit/WebKitBuild/DependenciesWPE/Source/dinghy/dy-webkit-utils.c:128:5: warning: implicit declaration of function ‘exit’ [-Wimplicit-function-declaration]
     exit (GPOINTER_TO_INT (userdata));
     ^~~~
/home/mcatanzaro/Projects/WebKit/WebKitBuild/DependenciesWPE/Source/dinghy/dy-webkit-utils.c:128:5: warning: incompatible implicit declaration of built-in function ‘exit’
/home/mcatanzaro/Projects/WebKit/WebKitBuild/DependenciesWPE/Source/dinghy/dy-webkit-utils.c:128:5: note: include ‘<stdlib.h>’ or provide a declaration of ‘exit’
```