### PR TITLE
WebDriver: Allow running dinghy in automation mode

### DIFF
--- a/dy-launcher.h
+++ b/dy-launcher.h
@@ -52,6 +52,8 @@ void              dy_launcher_set_request_handler (DyLauncher       *launcher,
                                                    const char       *scheme,
                                                    DyRequestHandler *handler);
 
+void              dy_launcher_enable_automation   (DyLauncher       *launcher);
+
 G_END_DECLS
 
 #endif /* !DY_LAUNCHER_H */


### PR DESCRIPTION
This is needed to enable remotely controlling a Dinghy instance by using WebDriver.

Fixes #7